### PR TITLE
Fix payment modal type error

### DIFF
--- a/frontend/app/components/PaymentModal.tsx
+++ b/frontend/app/components/PaymentModal.tsx
@@ -383,7 +383,7 @@ function PaymentForm({ tier, currency, onSuccess, onBack }: PaymentFormProps) {
         {/* Submit Button */}
         <button
           type="submit"
-          disabled={!stripe || !stripeReady || isProcessing || !cardReady || paymentStep === 'processing'}
+          disabled={!stripe || !stripeReady || isProcessing || !cardReady}
           className="w-full bg-gradient-to-r from-blue-500 to-blue-600 text-white py-3 px-4 rounded-lg font-medium hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 flex items-center justify-center space-x-2"
         >
           {isProcessing ? (


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove redundant `paymentStep` check from PaymentModal button disabled state to fix TypeScript error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Due to early returns for other `paymentStep` states, TypeScript narrows `paymentStep` to `'form'` when the button is rendered. The comparison `paymentStep === 'processing'` was therefore always false and flagged as an unintentional comparison. The `isProcessing` boolean already correctly handles the processing state for the button.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2dc23d9-ecfa-4f61-8143-cdaab1faefb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2dc23d9-ecfa-4f61-8143-cdaab1faefb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>