### PR TITLE
Update video generation intent for active images

### DIFF
--- a/app/core/model_config.py
+++ b/app/core/model_config.py
@@ -228,8 +228,8 @@ class ModelConfigManager:
                     "video_generation": {
                         "NEW_VIDEO": {"model": "veo-3.0-generate-preview", "generator": "google_ai"},
                         "NEW_VIDEO_REF": {"model": "veo-3.0-generate-preview", "generator": "google_ai"},
-                        "IMAGE_TO_VIDEO": {"model": "veo-3.0-generate-preview", "generator": "google_ai"},
-                        "IMAGE_TO_VIDEO_WITH_AUDIO": {"model": "veo-3.0-generate-preview", "generator": "google_ai"},
+                        "IMAGE_TO_VIDEO": {"model": "minimax/video-01", "generator": "replicate"},
+                        "IMAGE_TO_VIDEO_WITH_AUDIO": {"model": "minimax/video-01", "generator": "replicate"},
                         "EDIT_IMAGE_REF_TO_VIDEO": {"model": "veo-3.0-generate-preview", "generator": "google_ai"},
                         "EDIT_VIDEO": {"model": "runway_gen4_video"},
                         "EDIT_VIDEO_REF": {"model": "runway_gen4_video"}

--- a/app/services/simplified_flow_service.py
+++ b/app/services/simplified_flow_service.py
@@ -431,7 +431,7 @@ CRITICAL: If the video involves people communicating, conversing, or any scenari
 
 1. Active Image=NO, Uploaded Image=NO, Referenced Image=NO WITH AUDIO INTENT → Type: NEW_VIDEO_WITH_AUDIO, Model: Veo 3 (text-to-video with audio)
 2. Active Image=NO, Uploaded Image=NO, Referenced Image=NO WITHOUT AUDIO INTENT → Type: NEW_VIDEO, Model: MiniMax (text-to-video)
-3. Active Image=YES, Uploaded Image=NO, Referenced Image=NO WITH AUDIO INTENT → Type: IMAGE_TO_VIDEO_WITH_AUDIO, Model: MiniMax (image-to-video with audio)
+3. Active Image=YES, Uploaded Image=NO, Referenced Image=NO WITH AUDIO INTENT → Type: IMAGE_TO_VIDEO_WITH_AUDIO, Model: MiniMax (image-to-video with audio - NOT Veo even with audio!)
 4. Active Image=YES, Uploaded Image=NO, Referenced Image=NO WITHOUT AUDIO INTENT → Type: IMAGE_TO_VIDEO, Model: MiniMax (image-to-video)
 5. Active Image=YES AND (Uploaded Image=YES OR Referenced Image=YES) → Type: EDIT_IMAGE_REF_TO_VIDEO, Model: MiniMax (reference-based video)
 6. Active Image=NO AND (Uploaded Image=YES OR Referenced Image=YES) → Type: EDIT_IMAGE_REF_TO_VIDEO, Model: MiniMax (reference-based video)
@@ -993,7 +993,7 @@ IMPORTANT: Return ONLY the JSON object above. Do not add any extra analysis, exp
                 "NEW_VIDEO": "minimax/video-01",
                 "NEW_VIDEO_WITH_AUDIO": "google/veo-3",
                 "IMAGE_TO_VIDEO": "minimax/video-01",
-                "IMAGE_TO_VIDEO_WITH_AUDIO": "google/veo-3",
+                "IMAGE_TO_VIDEO_WITH_AUDIO": "minimax/video-01",
                 "EDIT_IMAGE_REF_TO_VIDEO": "minimax/video-01"
             }
             return fallback_mapping.get(prompt_type, "black-forest-labs/flux-1.1-pro")

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -33,13 +33,13 @@ model_routing:
         generator: "replicate"
         # No fallback - VEO-3-Fast is the only option for audio
       IMAGE_TO_VIDEO:
-        model: "gen4_turbo"
-        generator: "runway"
-        # No fallback - Runway is primary for image-to-video (bypass Hailuo-02 safety restrictions)
-      IMAGE_TO_VIDEO_WITH_AUDIO:
-        model: "google/veo-3-fast"
+        model: "minimax/video-01"
         generator: "replicate"
-        # No fallback - VEO-3-Fast is the only option for audio
+        # Use MiniMax for image-to-video (bypass Hailuo-02 safety restrictions)
+      IMAGE_TO_VIDEO_WITH_AUDIO:
+        model: "minimax/video-01"
+        generator: "replicate"
+        # Use standard image-to-video model when active image exists, even with audio intent
       EDIT_IMAGE_REF_TO_VIDEO:
         model: "gen4_turbo"
         generator: "runway"


### PR DESCRIPTION
Update video generation intent logic to use the standard image-to-video model (MiniMax) for requests involving an active image, even if audio is requested.

Previously, `IMAGE_TO_VIDEO_WITH_AUDIO` was incorrectly routed to Google Veo, which should only be used for new video generation with audio when no active image is present.

---
<a href="https://cursor.com/background-agent?bcId=bc-80ee1da7-9f22-4acd-9260-c3bc522608ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80ee1da7-9f22-4acd-9260-c3bc522608ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

