### PR TITLE
Fix await outside async function build error

### DIFF
--- a/app/services/generators/replicate.py
+++ b/app/services/generators/replicate.py
@@ -871,9 +871,9 @@ class ReplicateGenerator(BaseGenerator):
                         raise ValueError("Video editing requires a video URI")
                 elif "runway_gen4_image" in model_name or parameters.get("type") == "text_to_image_with_references":
                     # This shouldn't happen since runway image models are routed to _generate_runway_image
-                    # But if it does, redirect to image generation
-                    print(f"[DEBUG] Warning: runway image model in video path - redirecting to image generation")
-                    return await self._generate_runway_image(prompt, parameters)
+                    # But if it does, we can't call async methods from sync_call, so we'll raise an error
+                    print(f"[DEBUG] Error: runway image model in video path - this should be handled at a higher level")
+                    raise ValueError("Runway image generation should not be called from video generation path")
                 else:
                     # Image-to-video with gen4-turbo
                     image_uri = parameters.get("image") or parameters.get("prompt_image") or parameters.get("first_frame_image")


### PR DESCRIPTION
Fix `SyntaxError: 'await' outside async function` by preventing an invalid async call within a synchronous context.

The `_generate_video` method contained a nested `sync_call` function, intended for `asyncio.to_thread`. An `await` call to `_generate_runway_image` was incorrectly present within this `sync_call` for an unexpected model type, causing the build error on Render. The change replaces this with an error to prevent the invalid async call.

---
<a href="https://cursor.com/background-agent?bcId=bc-70a3442b-1a01-40d1-b156-d78e5d7eed44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70a3442b-1a01-40d1-b156-d78e5d7eed44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

